### PR TITLE
fix: add optional types to setup and utils functions

### DIFF
--- a/lua/age/init.lua
+++ b/lua/age/init.lua
@@ -11,7 +11,7 @@ M.from_sops = utils.from_sops
 
 --- Initializes the age plugin with the given configuration
 --- @param spec table|string The specification for age configuration. Can be either a table with a spec field or a direct spec value
---- @param opts table|nil Optional configuration table. If spec is a table with spec field, this parameter is ignored
+--- @param opts? table Optional configuration table. If spec is a table with spec field, this parameter is ignored
 --- @return nil|string Returns nil on success, or returns an error notification if age is not installed
 function M.setup(spec, opts)
     if type(spec) == "table" and spec.spec then

--- a/lua/age/utils.lua
+++ b/lua/age/utils.lua
@@ -4,7 +4,7 @@ local M = {}
 --- Decrypts and reads the contents of an age-encrypted file
 --- @param secret_path string Path to the encrypted file
 --- @param identity_filepath string Path to the age identity/key file
---- @param print_secret boolean Optional flag to print the decrypted content
+--- @param print_secret? boolean Optional flag to print the decrypted content
 --- @return string|nil The decrypted content with trailing newline removed, or nil if operation fails
 function M.get(secret_path, identity_filepath, print_secret)
     print_secret = print_secret or false
@@ -26,7 +26,7 @@ end
 --- Decrypts and reads the contents of an age-encrypted file, returning each line as a table entry
 --- @param secret_path string Path to the encrypted file
 --- @param identity_filepath string Path to the age identity/key file
---- @param print_secret boolean Optional flag to print the decrypted content
+--- @param print_secret? boolean Optional flag to print the decrypted content
 --- @return table|nil Table containing each line of the decrypted content as separate entries, or nil if operation fails
 function M.list(secret_path, identity_filepath, print_secret)
     print_secret = print_secret or false
@@ -48,7 +48,7 @@ end
 --- Decrypts an age-encrypted JSON file and returns its parsed contents
 --- @param secret_path string Path to the encrypted JSON file
 --- @param identity_filepath string Path to the age identity/key file
---- @param print_secret boolean Optional flag to print the decoded content
+--- @param print_secret? boolean Optional flag to print the decoded content
 --- @return table|nil Table containing the decoded JSON data, or nil if operation fails
 function M.from_json(secret_path, identity_filepath, print_secret)
     print_secret = print_secret or false
@@ -66,7 +66,7 @@ end
 
 --- Decrypts a SOPS-encrypted JSON file and returns its parsed contents
 --- @param secret_path string Path to the SOPS-encrypted file
---- @param print_secret boolean Optional flag to print the decoded content
+--- @param print_secret? boolean Optional flag to print the decoded content
 --- @return table|nil Table containing the decoded JSON data, or nil if operation fails
 function M.from_sops(secret_path, print_secret)
     print_secret = print_secret or false


### PR DESCRIPTION
Adding appropriate optional type hints for `print_secret` to get rid of the unnecessary warning.

### Before

![Age-nvim optional param warning](https://github.com/user-attachments/assets/fc48bcf5-dc2b-4d52-b087-9b4b56bcf54f)


### After

![Age-nvim no warning](https://github.com/user-attachments/assets/f2de11b9-2784-467c-b60c-e18a9dda1f90)

